### PR TITLE
Replace uri with addressable.

### DIFF
--- a/fluent-plugin-uri-parser.gemspec
+++ b/fluent-plugin-uri-parser.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "fluentd", "~> 0.12.0"
+  spec.add_runtime_dependency "addressable"
 
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "bundler", "~> 1.11"

--- a/lib/fluent/plugin/filter_uri_parser.rb
+++ b/lib/fluent/plugin/filter_uri_parser.rb
@@ -1,11 +1,6 @@
 class Fluent::URIParserFilter < Fluent::Filter
   Fluent::Plugin.register_filter("uri_parser", self)
 
-  DEFAULT_PORT_MAP = {
-    "http" => 80,
-    "https" => 443
-  }
-
   config_param :key_name, :string
   config_param :hash_value_field, :string, default: nil
   config_param :inject_key_prefix, :string, default: nil

--- a/test/plugin/test_filter_uri_parser.rb
+++ b/test/plugin/test_filter_uri_parser.rb
@@ -25,7 +25,7 @@ class URIParserFilterTest < Test::Unit::TestCase
     d1.run do
       d1.filter({ "url" => "http://example.com" }, @time)
       d1.filter({ "url" => "https://example.com/over/there?foo=bar&hoge=fuga" }, @time)
-      d1.filter({ "url" => "http://example.com/?id=25#time=1305212049" }, @time)
+      d1.filter({ "url" => "http://example.com:8080/?id=25#time=1305212049" }, @time)
     end
     filtered = d1.filtered_as_array
     assert_equal 3, filtered.length
@@ -49,7 +49,7 @@ class URIParserFilterTest < Test::Unit::TestCase
     data = filtered[2][2]
     assert_equal "http",            data["scheme"]
     assert_equal "example.com",     data["host"]
-    assert_equal 80,                data["port"]
+    assert_equal 8080,              data["port"]
     assert_equal "/",               data["path"]
     assert_equal "id=25",           data["query"]
     assert_equal "time=1305212049", data["fragment"]


### PR DESCRIPTION
URI.parse is different behavior on the version 2.1 and 2.2.

Using the addressable order to compensate for the difference.
