### PR TITLE
Parse non-ascii characters in www form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/lib/fluent/plugin/filter_query_string_parser.rb
+++ b/lib/fluent/plugin/filter_query_string_parser.rb
@@ -13,7 +13,7 @@ module Fluent
 
       def initialize
         super
-        require "uri"
+        require "addressable/uri"
       end
 
       def filter(tag, time, record)
@@ -27,7 +27,7 @@ module Fluent
         end
 
         begin
-          params = URI.decode_www_form(raw_value)
+          params = Addressable::URI.form_unencode(raw_value)
 
           unless params.empty?
             if @multi_value_params

--- a/test/plugin/test_filter_query_string_parser.rb
+++ b/test/plugin/test_filter_query_string_parser.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "helper"
 
 class QueryStringParserFilterTest < Test::Unit::TestCase
@@ -28,6 +29,23 @@ class QueryStringParserFilterTest < Test::Unit::TestCase
     assert_equal "bar",               records[0]["foo"]
     assert_equal "fuga",              records[0]["hoge"]
   end
+
+  def test_filter_non_ascii
+    config = %[
+      key_name query
+    ]
+
+    d1 = create_driver(config)
+    d1.run(default_tag: @tag) do
+      d1.feed(@time, { "query" => "тест=тестович" })
+    end
+    records = d1.filtered_records
+
+    assert_equal 1, records.length
+
+    assert_equal "тестович", records[0]["тест"]
+  end
+
 
   def test_filter_ignore_key_not_exist
     config = %[


### PR DESCRIPTION
This is not supposed to happen, but infortunately it does. Considering
that usual use of fluent is to parse all sort of non-standards
following logs it might be better to be a bit relaxed about standards.

Signed-off-by: Nikolay Martynov <mar.kolya@gmail.com>