### PR TITLE
Add multi_value_param_names option and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,266 @@
 # fluent-plugin-uri-parser
 
-[![Gem Version](https://badge.fury.io/rb/fluent-plugin-uri-parser.svg)](https://badge.fury.io/rb/fluent-plugin-uri-parser) [![test](https://github.com/daichirata/fluent-plugin-uri-parser/actions/workflows/test.yml/badge.svg)](https://github.com/daichirata/fluent-plugin-uri-parser/actions/workflows/test.yml)
+[![Gem Version](https://badge.fury.io/rb/fluent-plugin-uri-parser.svg)](https://badge.fury.io/rb/fluent-plugin-uri-parser)
+[![test](https://github.com/daichirata/fluent-plugin-uri-parser/actions/workflows/test.yml/badge.svg)](https://github.com/daichirata/fluent-plugin-uri-parser/actions/workflows/test.yml)
 
-This is a Fluentd plugin to parse uri and query string in log messages.
+Fluentd filter plugins that **decompose URIs and query strings into structured fields**, so you can search, group, and aggregate on them in your downstream stack.
+
+```text
+"https://example.com:8080/search?q=fluentd&lang=ja"
+                                ↓
+{ scheme: "https", host: "example.com", port: 8080,
+  path: "/search", query: "q=fluentd&lang=ja", fragment: nil }
+```
+
+## Why?
+
+URL strings sitting in a single log field are a black box — you can't filter by host, group by path, or count by query parameter without parsing them first. These filters turn a raw URL into a record your storage can index.
+
+| Plugin | Turns this | Into this |
+|---|---|---|
+| `uri_parser` | `https://example.com:8080/p?q=1#x` | `scheme`, `host`, `port`, `path`, `query`, `fragment` |
+| `query_string_parser` | `foo=bar&hoge=fuga` | `{ "foo" => "bar", "hoge" => "fuga" }` |
 
 ## Requirements
 
-| fluent-plugin-uri-parser  | fluentd    | ruby   |
-|---------------------------|------------|--------|
-| >= 0.4.0                  | >= v1.0.0  | >= 3.2 |
-| >= 0.3.0                  | >= v0.14.0 | >= 2.1 |
-|  < 0.2.0                  | >= v0.12.0 | >= 1.9 |
+| fluent-plugin-uri-parser | fluentd     | ruby   |
+| ------------------------ | ----------- | ------ |
+| >= 0.4.0                 | >= v1.0.0   | >= 3.2 |
+| >= 0.3.0                 | >= v0.14.0  | >= 2.1 |
+|  < 0.2.0                 | >= v0.12.0  | >= 1.9 |
 
 ## Installation
 
-``` shell
-$ gem install fluent-plugin-uri-parser
+```shell
+gem install fluent-plugin-uri-parser
 ```
 
-## Component
+Or in your `Gemfile`:
 
-### URIParserFilter
-
-This is a Fluentd plugin to parse and filtering uri in log messages and re-emit them.
-
-### QueryStringParserFilter
-
-This is a Fluentd plugin to parse and filtering query string in log messages and re-emit them.
-
-## Configuration
-
+```ruby
+gem "fluent-plugin-uri-parser"
 ```
-<filter>
+
+---
+
+## `uri_parser`
+
+Decomposes a URI field into its components.
+
+### Minimal example
+
+```aconf
+<filter access.log>
   @type uri_parser
-  key_name uri
-  inject_key_prefix parsed
-  # hash_value_field parsed
-  # suppress_parse_error_log false
-  # ignore_key_not_exist false
-  # ignore_nil false
-
-  out_key_scheme scheme
-  out_key_host host
-  out_key_port port
-  out_key_path path
-  out_key_query query
+  key_name url
+  out_key_scheme   scheme
+  out_key_host     host
+  out_key_port     port
+  out_key_path     path
+  out_key_query    query
   out_key_fragment fragment
 </filter>
-# input string of data: {"uri": "http://example.com/path?foo=bar#t=1"}
-# output data: {"parsed.scheme":"http","parsed.host":"example.com","parsed.port":80,"parsed.path":"/path","parsed.query":"foo=bar","parsed.ragment":"t=1"}
-
-<filter>
-  @type query_string_parser
-  key_name parsed.query
-  hash_value_field query
-  # inject_key_prefix query
-  # suppress_parse_error_log false
-  # ignore_key_not_exist false
-</filter>
-# input string of data: {"parsed.query": "foo=bar"}
-# output data: {"query":{"foo":"bar"}}
-
 ```
 
-**key_name (Required)**
+```jsonc
+// input
+{ "url": "https://example.com:8080/search?q=fluentd#top" }
 
-Key of the value to be parsed in the record.
+// output
+{
+  "url":      "https://example.com:8080/search?q=fluentd#top",
+  "scheme":   "https",
+  "host":     "example.com",
+  "port":     8080,
+  "path":     "/search",
+  "query":    "q=fluentd",
+  "fragment": "top"
+}
+```
 
-**hash_value_field (Default: '')**
+> The `port` value uses [`Addressable::URI#inferred_port`](https://github.com/sporkmonger/addressable), so well-known schemes (`http` → 80, `https` → 443, ...) get a port even when the URL omits one.
 
-If a value is set, the value after parsing is stored in hash with key specified value.
+### Group output under a single key — `hash_value_field`
 
-**inject_key_prefix (Default: '')**
+```aconf
+<filter access.log>
+  @type uri_parser
+  key_name url
+  hash_value_field parsed
+  out_key_host host
+  out_key_path path
+</filter>
+```
 
-If you set a value, set the value specified for the key after parsing as prefix.
+```jsonc
+// input
+{ "url": "https://example.com/search" }
 
-**suppress_parse_error_log (Default: false)**
+// output
+{
+  "url": "https://example.com/search",
+  "parsed": { "host": "example.com", "path": "/search" }
+}
+```
 
-If set to `true`, no error log is output even if parsing fails.
+### Namespace output keys — `inject_key_prefix`
 
-**ignore_key_not_exist (Default: false)**
+```aconf
+<filter access.log>
+  @type uri_parser
+  key_name url
+  inject_key_prefix url.
+  out_key_host host
+  out_key_path path
+</filter>
+```
 
-If set to `true`, if the field specified by `key_name` does not exist, the record will not be emit to the next stream. That means that the data will be lost there.
+```jsonc
+// input
+{ "url": "https://example.com/search" }
 
-**ignore_nil (Default: false)**
+// output
+{
+  "url":      "https://example.com/search",
+  "url.host": "example.com",
+  "url.path": "/search"
+}
+```
 
-If set to `true`, exclude key if the value after parse is nil.
+### Drop empty components — `ignore_nil`
 
-**multi_value_params (Default: false)**
+When a component is missing (no query, no fragment, etc.) the default is to emit it as `null`. Set `ignore_nil true` to omit those keys entirely.
 
-If set to `true`, then resulting values would be arrays containing
-potentially multiple values of a given parameter.
+```jsonc
+// input
+{ "url": "https://example.com/path" }
+
+// ignore_nil false  (default)
+{ "scheme": "https", "host": "example.com", "port": 443,
+  "path": "/path", "query": null, "fragment": null }
+
+// ignore_nil true
+{ "scheme": "https", "host": "example.com", "port": 443,
+  "path": "/path" }
+```
+
+---
+
+## `query_string_parser`
+
+Decomposes a query string field into individual parameters.
+
+### Minimal example
+
+```aconf
+<filter access.log>
+  @type query_string_parser
+  key_name query
+</filter>
+```
+
+```jsonc
+// input
+{ "query": "foo=bar&hoge=fuga" }
+
+// output
+{ "query": "foo=bar&hoge=fuga", "foo": "bar", "hoge": "fuga" }
+```
+
+### Group output under a single key — `hash_value_field`
+
+```aconf
+<filter access.log>
+  @type query_string_parser
+  key_name query
+  hash_value_field params
+</filter>
+```
+
+```jsonc
+// input
+{ "query": "foo=bar&hoge=fuga" }
+
+// output
+{
+  "query":  "foo=bar&hoge=fuga",
+  "params": { "foo": "bar", "hoge": "fuga" }
+}
+```
+
+### Handle repeated parameters
+
+A request like `?tag=ruby&tag=fluentd` has two `tag` values. By default the last one wins (scalar). You have two ways to keep both:
+
+#### Option A: always arrays — `multi_value_params true`
+
+Every parameter becomes an array, even when it appeared once.
+
+```jsonc
+// input
+{ "query": "tag=ruby&tag=fluentd&lang=ja" }
+
+// output
+{ "tag": ["ruby", "fluentd"], "lang": ["ja"] }
+```
+
+#### Option B: array only for listed names — `multi_value_param_names`
+
+You know `tag` may repeat but `lang` won't. Keep `lang` as a scalar and only wrap `tag` in an array.
+
+```aconf
+<filter access.log>
+  @type query_string_parser
+  key_name query
+  multi_value_param_names tag
+</filter>
+```
+
+```jsonc
+// input
+{ "query": "tag=ruby&tag=fluentd&lang=ja" }
+
+// output
+{ "tag": ["ruby", "fluentd"], "lang": "ja" }
+```
+
+> When both are set, `multi_value_params true` wins.
+
+---
+
+## Options
+
+Shared between both filters unless noted.
+
+| Option | Type | Default | What it does |
+| --- | --- | --- | --- |
+| `key_name` | string | — *(required)* | Record key holding the URL or query string to parse. |
+| `hash_value_field` | string | `nil` | If set, all extracted fields are nested under this key. |
+| `inject_key_prefix` | string | `nil` | Prefix prepended to every extracted key. |
+| `ignore_key_not_exist` | bool | `false` | When `key_name` is missing, drop the record instead of passing it through. |
+| `emit_invalid_record_to_error` | bool | `true` | When `key_name` is missing, emit the record to Fluentd's error stream. |
+| `suppress_parse_error_log` | bool | `false` | Silence the warning log when the value fails to parse. |
+| `ignore_nil` | bool | `false` | *(uri_parser only)* Omit output keys whose parsed value is `nil`. |
+| `out_key_scheme` / `out_key_host` / `out_key_port` / `out_key_path` / `out_key_query` / `out_key_fragment` | string | `nil` | *(uri_parser only)* Output key name for each URI component. Components without an `out_key_*` are not emitted. |
+| `multi_value_params` | bool | `false` | *(query_string_parser only)* Emit every parameter as an array. |
+| `multi_value_param_names` | array | `nil` | *(query_string_parser only)* Emit only the listed parameters as arrays. Ignored when `multi_value_params` is `true`. |
+
+---
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+```shell
+bundle install
+bundle exec rake test
+```
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine: `bundle exec rake install`.
+To release: bump the version in the gemspec, then `bundle exec rake release` (tags, pushes, and uploads to [rubygems.org](https://rubygems.org)).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/daichirata/fluent-plugin-uri-parser.
+Bug reports and pull requests are welcome at <https://github.com/daichirata/fluent-plugin-uri-parser>.
 
+## License
+
+Apache-2.0

--- a/lib/fluent/plugin/filter_query_string_parser.rb
+++ b/lib/fluent/plugin/filter_query_string_parser.rb
@@ -13,6 +13,7 @@ module Fluent
       config_param :ignore_key_not_exist, :bool, default: false
       config_param :emit_invalid_record_to_error, :bool, default: true
       config_param :multi_value_params, :bool, default: false
+      config_param :multi_value_param_names, :array, default: nil
 
       def filter(tag, time, record)
         raw_value = record[@key_name]
@@ -31,6 +32,15 @@ module Fluent
             if @multi_value_params
               values = Hash.new {|h,k| h[k] = [] }
               params.each{|pair| values[pair[0]].push(pair[1])}
+            elsif @multi_value_param_names
+              values = {}
+              params.each do |k, v|
+                if @multi_value_param_names.include?(k)
+                  (values[k] ||= []) << v
+                else
+                  values[k] = v
+                end
+              end
             else
               values = Hash[params]
             end

--- a/test/plugin/test_filter_query_string_parser.rb
+++ b/test/plugin/test_filter_query_string_parser.rb
@@ -101,6 +101,62 @@ class QueryStringParserFilterTest < Test::Unit::TestCase
     assert_equal ["fuga"],                      records[0]["parsed"]["hoge"]
   end
 
+  def test_filter_multi_value_param_names
+    config = %[
+      key_name query
+      hash_value_field parsed
+      multi_value_param_names foo
+    ]
+
+    d1 = create_driver(config)
+    d1.run(default_tag: @tag) do
+      d1.feed(@time, { "query" => "foo=bar1&hoge=fuga&foo=bar2" })
+    end
+    records = d1.filtered_records
+
+    assert_equal 1, records.length
+    assert_equal ["bar1", "bar2"], records[0]["parsed"]["foo"]
+    assert_equal "fuga",           records[0]["parsed"]["hoge"]
+  end
+
+  def test_filter_multi_value_param_names_with_single_occurrence
+    config = %[
+      key_name query
+      hash_value_field parsed
+      multi_value_param_names foo,bar
+    ]
+
+    d1 = create_driver(config)
+    d1.run(default_tag: @tag) do
+      d1.feed(@time, { "query" => "foo=1&bar=2&hoge=fuga" })
+    end
+    records = d1.filtered_records
+
+    assert_equal 1, records.length
+    assert_equal ["1"],   records[0]["parsed"]["foo"]
+    assert_equal ["2"],   records[0]["parsed"]["bar"]
+    assert_equal "fuga",  records[0]["parsed"]["hoge"]
+  end
+
+  def test_filter_multi_value_params_takes_precedence_over_names
+    config = %[
+      key_name query
+      hash_value_field parsed
+      multi_value_params true
+      multi_value_param_names foo
+    ]
+
+    d1 = create_driver(config)
+    d1.run(default_tag: @tag) do
+      d1.feed(@time, { "query" => "foo=bar1&hoge=fuga&foo=bar2" })
+    end
+    records = d1.filtered_records
+
+    assert_equal 1, records.length
+    assert_equal ["bar1", "bar2"], records[0]["parsed"]["foo"]
+    assert_equal ["fuga"],         records[0]["parsed"]["hoge"]
+  end
+
   def test_filter_inject_key_prefix
     config = %[
       key_name query


### PR DESCRIPTION
Closes #7

## Summary
- Add `multi_value_param_names` to `query_string_parser` so users can promote only listed parameters to arrays, instead of forcing every parameter into an array via `multi_value_params true`
- `multi_value_params true` keeps precedence when both are set, so existing configurations are unaffected
- Rewrite the README with input → output examples for every option and a single options table

## Behavior

| Config | Input | Output |
| --- | --- | --- |
| *(none)* | `tag=ruby&tag=fluentd&lang=ja` | `{ "tag": "fluentd", "lang": "ja" }` (last wins) |
| `multi_value_params true` | same | `{ "tag": ["ruby", "fluentd"], "lang": ["ja"] }` |
| `multi_value_param_names tag` | same | `{ "tag": ["ruby", "fluentd"], "lang": "ja" }` |

## Test plan
- [x] `bundle exec rake test` (20 tests / 87 assertions / 0 failures)
- [x] Added tests covering: single-name array, multi-name with single-occurrence values still wrapped, `multi_value_params` precedence over `multi_value_param_names`
- [ ] GitHub Actions matrix passes on Ruby 3.2 / 3.3 / 3.4 / 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)