### PR TITLE
Drop empty-key pairs in query_string_parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ When a component is missing (no query, no fragment, etc.) the default is to emit
 
 Decomposes a query string field into individual parameters.
 
+> Pairs with an empty key (e.g. the leading `&` in `&foo=1`) are silently dropped — they're noise from user-supplied URLs and never represent a real parameter.
+
 ### Minimal example
 
 ```aconf

--- a/lib/fluent/plugin/filter_query_string_parser.rb
+++ b/lib/fluent/plugin/filter_query_string_parser.rb
@@ -27,6 +27,7 @@ module Fluent
 
         begin
           params = Addressable::URI.form_unencode(raw_value)
+          params = params.reject {|k, _| k.nil? || k.empty? }
 
           unless params.empty?
             if @multi_value_params

--- a/test/plugin/test_filter_query_string_parser.rb
+++ b/test/plugin/test_filter_query_string_parser.rb
@@ -30,6 +30,29 @@ class QueryStringParserFilterTest < Test::Unit::TestCase
     assert_equal "fuga",              records[0]["hoge"]
   end
 
+  def test_filter_drops_empty_keys
+    config = %[
+      key_name query
+      hash_value_field parsed
+    ]
+
+    d1 = create_driver(config)
+    d1.run(default_tag: @tag) do
+      d1.feed(@time, { "query" => "&partnerid=12345" })
+      d1.feed(@time, { "query" => "=value&foo=bar" })
+      d1.feed(@time, { "query" => "&&foo=bar&&" })
+      d1.feed(@time, { "query" => "foo=&bar=baz" })
+    end
+    records = d1.filtered_records
+
+    assert_equal 4, records.length
+
+    assert_equal({ "partnerid" => "12345" }, records[0]["parsed"])
+    assert_equal({ "foo" => "bar" },         records[1]["parsed"])
+    assert_equal({ "foo" => "bar" },         records[2]["parsed"])
+    assert_equal({ "foo" => "", "bar" => "baz" }, records[3]["parsed"])
+  end
+
   def test_filter_non_ascii
     config = %[
       key_name query


### PR DESCRIPTION
Closes #6

## Summary
- `Addressable::URI.form_unencode` returns pairs with `nil` or empty-string keys for stray delimiters in the input (`&foo=bar`, `=value`, `&&`, etc.). These polluted the emitted record with an `"" => ""` entry
- Filter pairs where the key is `nil` or empty before building the output hash
- Pairs with an empty value but a real key (`foo=`) are preserved — they represent an intentional empty parameter

## Behavior

| Input | Before | After |
| --- | --- | --- |
| `&partnerid=12345` | `{ "" => "", "partnerid" => "12345" }` | `{ "partnerid" => "12345" }` |
| `=value&foo=bar` | `{ "" => "value", "foo" => "bar" }` | `{ "foo" => "bar" }` |
| `&&foo=bar&&` | extra `"" => ""` pairs | `{ "foo" => "bar" }` |
| `foo=&bar=baz` *(unchanged)* | `{ "foo" => "", "bar" => "baz" }` | `{ "foo" => "", "bar" => "baz" }` |

## Test plan
- [x] `bundle exec rake test` (21 tests / 92 assertions / 0 failures)
- [x] Added `test_filter_drops_empty_keys` covering leading/middle/trailing delimiters and the intentionally empty-value case
- [ ] GitHub Actions matrix passes on Ruby 3.2 / 3.3 / 3.4 / 4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)